### PR TITLE
Add GitHub Skills activity for student registration

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the GitHub Skills activity to resolve issue #6 - the missing activity announced by the principal.

## Changes
- Added "GitHub Skills" activity to the activities list in `app.py`
- Activity details:
  - **Description:** Learn practical coding and collaboration skills with GitHub. First part of our GitHub Certifications program to help with college applications.
  - **Schedule:** Mondays and Thursdays, 3:30 PM - 4:30 PM
  - **Capacity:** 25 participants
  - **Status:** Open for registrations

## Impact
Students can now see and register for the GitHub Skills activity announced by the principal during the school assembly. This makes the activity available before registration closes at the end of the week.

## Closes
Fixes #6